### PR TITLE
Fix i2c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM arm32v7/python:3.7-alpine
 
+COPY qemu-arm-static /usr/bin/
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM arm32v6/python:3-alpine3.7
-COPY qemu-arm-static /usr/bin/
+FROM arm32v7/python:3.7-alpine
+
 
 COPY . .
 
-RUN apk --update add python py-pip openssl ca-certificates py-openssl wget
-RUN apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base \
+RUN apk update
+RUN apk upgrade
+
+RUN apk add python py-pip openssl ca-certificates py-openssl wget
+RUN apk add --virtual build-dependencies libffi-dev openssl-dev python3-dev py-pip build-base \
   && pip install --upgrade pip \
-  && pip install -r requirements.txt \
+  && pip install --no-cache-dir -r requirements.txt \
   && apk del build-dependencies
+
+WORKDIR rasp/
 
 ENV PYTHONUNBUFFERED 1
 
-ENTRYPOINT ["python3", "rasp/run.py"]
-
+ENTRYPOINT ["python3", "run.py"]

--- a/arduino/i2c/i2c.ino
+++ b/arduino/i2c/i2c.ino
@@ -1,12 +1,12 @@
 #include <Wire.h>
 
-#define SlaveAddress 0x8
+#define SLAVE_ADDRESS 0x8
 
 void sendData();
 
 void setup() {
   // Start the connections as a slave
-  Wire.begin(SlaveAddress);
+  Wire.begin(SLAVE_ADDRESS);
   // When the R_Pi requests data from the arduino, call the sendData function.
   Wire.onRequest(sendData);
 }
@@ -29,21 +29,19 @@ void ldrIntToByte (int ldrValues[], byte ldrByteValues[], int ldrLength) {
 
 void sendData() {
   // Collects the data from the LDRs, storing it within the ldrIntValues array
+
   int ldrIntValues[] = {analogRead(A1), analogRead(A0)}; // The left LDR must always come before the right LDR
 
   // Length of the LDR's value array and length of LDR's byte value array
   int ldrLength = (sizeof(ldrIntValues) / sizeof(ldrIntValues[0]));
   int ldrByteLength = ldrLength * 2;
-
+  
   // Declares an array which will store the byte values
   byte ldrArray[ldrByteLength];
 
   // Transforms the integers into bytes
   ldrIntToByte(ldrIntValues, ldrArray, ldrLength);
-
-  // Sends the data individually via I²C to the Raspberry Pi
-  for (int i = 0; i < ldrByteLength; i += 2) {
-      byte submissionValuesArray[] = {ldrArray[i], ldrArray[i+1]};
-      Wire.write(submissionValuesArray, 2);
-  }
+ 
+  // Transfers the data through I²C 
+  Wire.write(ldrArray, ldrByteLength);
 }

--- a/rasp/i2c_connector.py
+++ b/rasp/i2c_connector.py
@@ -1,5 +1,4 @@
-from smbus2 import SMBus
-
+import quick2wire.i2c as i2c
 
 class I2C:
     """
@@ -8,7 +7,6 @@ class I2C:
     """
 
     def __init__(self, address, number_of_ldrs=2):
-        self.connector = SMBus(1)
         self.SLAVE_ADDRESS = address
         self.number_of_ldrs = number_of_ldrs
 
@@ -19,8 +17,13 @@ class I2C:
         Returns:
             list -- List with n bytes representing the LDR values.
         """
-        return self.connector.read_i2c_block_data(self.SLAVE_ADDRESS, 1,
-                                                  (self.number_of_ldrs * 2))
+
+        with i2c.I2CMaster() as bus:
+            data = bus.transaction(i2c.reading(self.SLAVE_ADDRESS,
+                                               self.number_of_ldrs * 2))
+            ldr_values = [data[0][i] for i in range(self.number_of_ldrs *2)]
+            
+            return ldr_values
 
     def get_ldr_values(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ six==1.14.0
 smbus2==0.3.0
 wcwidth==0.1.8
 zipp==2.2.0
+quick2wire-api==0.0.0.2


### PR DESCRIPTION
Change the python library used to establish the I²C connection between the Raspberry Pi and the Arduino.
Library:
- smbus2 -> quick2wire.

Modify the Docker image used to run the software due to Raspberry Pi 2's architecture.